### PR TITLE
docs: add Digital Agency Design System reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ tailwind.config.ts   Tailwind + NextUI plugin setup
 - Component styles stay next to their implementation (`Component.tsx`, `Component.scss`, `Component.stories.ts`).
 - `src/app/providers.tsx` wraps the tree with `NextUIProvider` so HeroUI/NextUI components share theme state.
 - The `Twemoji` atom serves emoji as SVGs via CDN, and Font Awesome is ready for icon usage in pages.
+- Uses [Digital Agency Design System](https://github.com/digital-go-jp/design-system-example-components-react) for accessible and government-standard UI components.
 
 ## Storybook & Demo Content
 


### PR DESCRIPTION
## Summary
- Added reference to Digital Agency Design System in the Styling & UI System section
- Clarifies that this project uses government-standard accessible UI components from https://github.com/digital-go-jp/design-system-example-components-react

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Confirm link to Digital Agency Design System repository works

🤖 Generated with [Claude Code](https://claude.com/claude-code)